### PR TITLE
v1.0.2: Python 3.x compatibility

### DIFF
--- a/rich_traceback/formatter.py
+++ b/rich_traceback/formatter.py
@@ -103,7 +103,7 @@ class RichTracebackFormatter(Formatter):
         trace = []
         frameNo = 0
         for frame, _, line, function, src, pos in frames:
-            code = src[pos].strip() if pos >= 0 else '(no source)'
+            code = src[pos].strip() if pos else '(no source)'
             name = self.get_frame_name(frame)
             if function == '?':
                 prettyargs = ''

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='rich-traceback',
-    version='1.0.2',
+    version='1.0.3',
     description='Rich Traceback Logger',
     long_description=('Informative Traceback Logging for Python\n\n'
                       'Informative stack traces showing method parameters\n'
@@ -27,6 +27,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
 
     keywords='traceback log syslog informative stack traces',


### PR DESCRIPTION
In newer versions of python, if source is not available, `pos` is not `0` but `None` instead, so let's handle both gracefully.